### PR TITLE
lsp: fix default path

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
             "type": [
               "string"
             ],
-            "default": true,
+            "default": "",
             "description": "Hardcode a path to the LSP executable"
           }
         }


### PR DESCRIPTION
copy-paste mistake, accidentally defaulted the config value to `true`