### PR TITLE
decomp: add `1` to the end range of a type-cast

### DIFF
--- a/src/decomp/type-caster.ts
+++ b/src/decomp/type-caster.ts
@@ -310,7 +310,7 @@ async function typeCastSelection() {
     if (endOpNum === undefined) {
       return;
     }
-    castContext.endOp = endOpNum;
+    castContext.endOp = endOpNum + 1;
   }
 
   // Get the relevant function/method name


### PR DESCRIPTION
the end range is not inclusive, it's counter intuitive to keep this in mind and also in some situations it's impossible as you need a cast to go to the very last OP number (range will be invalid if the last line doesn't have an op number to find)