### PR TITLE
decomp: enforce `decompile_code: true` when decompiling code

### DIFF
--- a/src/decomp/decomp-tools.ts
+++ b/src/decomp/decomp-tools.ts
@@ -216,7 +216,7 @@ async function decompFiles(decompConfig: string, fileNames: string[]) {
         "./iso_data",
         "./decompiler_out",
         "--config-override",
-        `{"allowed_objects": [${allowed_objects}]}`,
+        `{"decompile_code": true, "allowed_objects": [${allowed_objects}]}`,
       ],
       {
         encoding: "utf8",


### PR DESCRIPTION
The default jak1 config has this set to false which is incredibly annoying when you want to decompile an old file to compare against (have to go modify the json file and then remember to not commit it).  Fixes that