### PR TITLE
decomp: add a command to increment all `deftype`'s offsets by n

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "onCommand:opengoal.decomp.casts.labelCastSelection",
     "onCommand:opengoal.decomp.casts.stackCastSelection",
     "onCommand:opengoal.decomp.casts.typeCastSelection",
+    "onCommand:opengoal.decomp.misc.addToOffsets",
     "onCommand:opengoal.lsp.start",
     "onCommand:opengoal.lsp.stop",
     "onCommand:opengoal.lsp.restart"
@@ -115,6 +116,10 @@
       {
         "command": "opengoal.decomp.casts.typeCastSelection",
         "title": "OpenGOAL - Casts - Add Type Cast to Selection"
+      },
+      {
+        "command": "opengoal.decomp.misc.addToOffsets",
+        "title": "OpenGOAL - Misc - Add to deftype Offsets"
       },
       {
         "command": "opengoal.lsp.start",

--- a/src/decomp/misc-tools.ts
+++ b/src/decomp/misc-tools.ts
@@ -1,0 +1,47 @@
+import { getExtensionContext } from "../context";
+import * as vscode from "vscode";
+
+async function addToOffsets() {
+  const editor = vscode.window.activeTextEditor;
+  if (
+    editor === undefined ||
+    editor.selection.isEmpty ||
+    editor.selection.isSingleLine
+  ) {
+    return;
+  }
+
+  // Get amount to increment
+  const incString = await vscode.window.showInputBox({
+    title: "Increment By?",
+  });
+  if (incString === undefined) {
+    return;
+  }
+  const incAmount = parseInt(incString);
+
+  editor.edit((selectedText) => {
+    // Get the content of the selection
+    const content = editor.document.getText(editor.selection);
+
+    // Increment all values after `:offset` or `:offset-assert`
+    const result = content.replace(
+      /(?<=offset(?:-assert)?\s+)(\d+)(?=\s+|\))/g,
+      (match, key) => {
+        console.log(`${match}-${key}`);
+        return `${parseInt(key) + incAmount}`;
+      }
+    );
+
+    selectedText.replace(editor.selection, result);
+  });
+}
+
+export async function activateMiscDecompTools() {
+  getExtensionContext().subscriptions.push(
+    vscode.commands.registerCommand(
+      "opengoal.decomp.misc.addToOffsets",
+      addToOffsets
+    )
+  );
+}

--- a/src/decomp/type-caster.ts
+++ b/src/decomp/type-caster.ts
@@ -1,5 +1,3 @@
-// [inclusive, exclusive]
-
 import { getExtensionContext } from "../context";
 import * as vscode from "vscode";
 import { basename, join } from "path";
@@ -464,39 +462,3 @@ export async function activateTypeCastTools() {
     )
   );
 }
-
-// TODO - better handling around upserting casts
-// this requires properly handling the CommentArray type instead of building raw arrays so comments are preserved
-// const finalEntries = [];
-//   if (relevantJson !== undefined) {
-//     // prepare the entry for the upcoming update
-//     // remove any identical casts / range casts that effect it
-//     for (const entry of relevantJson) {
-//       if (entry[1] === registerSelection) {
-//         if (entry[0] instanceof Array) {
-//           const [start, end] = entry[0];
-//           if (castContext.endOp === undefined) {
-//             if (castContext.startOp >= start && castContext.startOp < end) {
-//               continue;
-//             }
-//           } else if (
-//             (castContext.startOp >= start && castContext.startOp < end) ||
-//             (castContext.endOp > start && castContext.endOp < end) ||
-//             (castContext.startOp >= start && castContext.endOp < end)
-//           ) {
-//             continue;
-//           }
-//         } else if (castContext.startOp == entry[0]) {
-//           continue;
-//         }
-//         finalEntries.push(entry);
-//       }
-//     }
-//     // Add our new entry
-//     // TODO - sort by op number (annoying because of the ranges...)
-//     if (castContext.endOp === undefined) {
-//       finalEntries.push([castContext.startOp, registerSelection, castToType]);
-//     } else {
-//       finalEntries.push([[castContext.startOp, castContext.endOp], registerSelection, castToType]);
-//     }
-//   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { IRFoldingRangeProvider } from "./languages/ir2/ir2-folder";
 import { activateTypeCastTools } from "./decomp/type-caster";
 import { IRInlayHintsProvider } from "./languages/ir2/ir2-inlay-hinter";
 import { OpenGOALDisasmRenameProvider } from "./languages/opengoal/disasm/opengoal-disasm-renamer";
+import { activateMiscDecompTools } from "./decomp/misc-tools";
 
 export async function activate(context: vscode.ExtensionContext) {
   try {
@@ -32,6 +33,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     activateDecompTools();
     activateTypeCastTools();
+    activateMiscDecompTools();
 
     // Customized PDF Viewer
     const provider = new PdfCustomProvider(


### PR DESCRIPTION
This is useful currently because we had an off-by-4 for process sub-types.  Quick and easy way to solve it