### PR TITLE
decomp: add a command to simplify block preservation

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "onCommand:opengoal.decomp.casts.stackCastSelection",
     "onCommand:opengoal.decomp.casts.typeCastSelection",
     "onCommand:opengoal.decomp.misc.addToOffsets",
+    "onCommand:opengoal.decomp.misc.preserveBlock",
     "onCommand:opengoal.lsp.start",
     "onCommand:opengoal.lsp.stop",
     "onCommand:opengoal.lsp.restart"
@@ -120,6 +121,10 @@
       {
         "command": "opengoal.decomp.misc.addToOffsets",
         "title": "OpenGOAL - Misc - Add to deftype Offsets"
+      },
+      {
+        "command": "opengoal.decomp.misc.preserveBlock",
+        "title": "OpenGOAL - Misc - Preserve Block"
       },
       {
         "command": "opengoal.lsp.start",

--- a/src/decomp/misc-tools.ts
+++ b/src/decomp/misc-tools.ts
@@ -1,5 +1,12 @@
 import { getExtensionContext } from "../context";
 import * as vscode from "vscode";
+import {
+  determineGameFromAllTypes,
+  findFileInGoalSrc,
+  GameName,
+  updateFileBeforeDecomp,
+} from "../utils/file-utils";
+import { getWorkspaceFolderByName } from "../utils/workspace";
 
 async function addToOffsets() {
   const editor = vscode.window.activeTextEditor;
@@ -37,11 +44,79 @@ async function addToOffsets() {
   });
 }
 
+async function preserveBlock() {
+  const editor = vscode.window.activeTextEditor;
+  if (
+    editor === undefined ||
+    editor.selection.isEmpty ||
+    editor.selection.isSingleLine
+  ) {
+    return;
+  }
+
+  // Ask the user for the file name
+  const fileName = await vscode.window.showInputBox({
+    title: "File Name?",
+  });
+  // Ask the user for the block name
+  const blockName = await vscode.window.showInputBox({
+    title: "Block Name?",
+  });
+
+  if (fileName === undefined || blockName === undefined) {
+    return;
+  }
+
+  let blockContent = "";
+
+  // Wrap the block in `all-types`
+  editor.edit((selectedText) => {
+    // Get the content of the selection
+    const content = editor.document.getText(editor.selection);
+    blockContent = content;
+    selectedText.replace(
+      editor.selection,
+      `;; +++${fileName}:${blockName}\n${content}\n;; ---${fileName}:${blockName}`
+    );
+  });
+
+  // Go and place the block in the file
+  const game = determineGameFromAllTypes(editor.document.uri);
+  const projectRoot = getWorkspaceFolderByName("jak-project");
+  if (projectRoot === undefined) {
+    vscode.window.showErrorMessage(
+      "OpenGOAL - Unable to locate 'jak-project' workspace folder"
+    );
+    return undefined;
+  }
+
+  let gameName = "jak1";
+  if (game === GameName.Jak2) {
+    gameName = "jak2";
+  }
+
+  const gsrcPath = await findFileInGoalSrc(projectRoot, gameName, fileName);
+  if (gsrcPath === undefined) {
+    return;
+  }
+  // Otherwise, let's update it...
+  await updateFileBeforeDecomp(
+    gsrcPath,
+    `;; +++${blockName}\n${blockContent}\n;; ---${blockName}`
+  );
+}
+
 export async function activateMiscDecompTools() {
   getExtensionContext().subscriptions.push(
     vscode.commands.registerCommand(
       "opengoal.decomp.misc.addToOffsets",
       addToOffsets
+    )
+  );
+  getExtensionContext().subscriptions.push(
+    vscode.commands.registerCommand(
+      "opengoal.decomp.misc.preserveBlock",
+      preserveBlock
     )
   );
 }


### PR DESCRIPTION
This quickly wraps the selected block in the recognized comments, 
![image](https://user-images.githubusercontent.com/13153231/189815410-0b5a3c69-50ba-4a8d-aefa-ec64ecf66df8.png)
and will copy it over to the gsrc file automatically
![image](https://user-images.githubusercontent.com/13153231/189815465-841d9f92-06da-4a71-b4e9-ba8603e49f34.png)

