### PR TITLE
decomp: consolidate switching back from all-types to the same `switch file` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "onLanguage:opengoal-goos",
     "onLanguage:opengoal-ir",
     "onCommand:opengoal.switchFile",
-    "onCommand:opengoal.decomp.openMostRecentIRFile",
     "onCommand:opengoal.decomp.openManPage",
     "onCommand:opengoal.decomp.decompileSpecificFile",
     "onCommand:opengoal.decomp.decompileCurrentFile",

--- a/src/decomp/decomp-tools.ts
+++ b/src/decomp/decomp-tools.ts
@@ -392,10 +392,6 @@ async function decompAllActiveFiles() {
   }
 }
 
-function openMostRecentIRFile() {
-  openFile(getRecentFiles().searchByPrefix("_ir2.asm"));
-}
-
 function openManPage() {
   const editor = vscode.window.activeTextEditor;
   if (!editor) {
@@ -564,12 +560,6 @@ export async function activateDecompTools() {
   decompStatusItem.show();
 
   // Commands
-  getExtensionContext().subscriptions.push(
-    vscode.commands.registerCommand(
-      "opengoal.decomp.openMostRecentIRFile",
-      openMostRecentIRFile
-    )
-  );
   getExtensionContext().subscriptions.push(
     vscode.commands.registerCommand("opengoal.decomp.openManPage", openManPage)
   );

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -1,8 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { promises as fs } from "fs";
-
-// TODO - remove "most recent ir2 file, and wire it up here when in an `all-types.gc` file"
+import { getRecentFiles } from "../context";
 
 export enum GameName {
   Jak1,
@@ -20,6 +19,10 @@ export function switchFile() {
     return;
   }
   const currName = path.basename(currPath);
+  // all-types is handled a little different, we find the most recent IR2 file
+  if (currName === "all-types.gc") {
+    openFile(getRecentFiles().searchByPrefix("_ir2.asm"));
+  }
   for (const [key, value] of Object.entries(fileSwitchingAssoc)) {
     if (currName.endsWith(key)) {
       // Get everything before the suffix, check if a file with the associated suffix exists


### PR DESCRIPTION
Closes #62 