### PR TITLE
misc: handle `r0` edge-case when loading value

### DIFF
--- a/src/decomp/misc-tools.ts
+++ b/src/decomp/misc-tools.ts
@@ -279,6 +279,13 @@ async function genTypeFields() {
             } else {
               loadInstr = line.trim().split(" ")[0];
             }
+          } else if (line.includes("r0")) {
+            offset = 0;
+            if (line.includes("daddiu")) {
+              loadInstr = "daddiu";
+            } else {
+              loadInstr = line.trim().split(" ")[0];
+            }
           } else {
             return;
           }


### PR DESCRIPTION
Sometimes the first value in the type isn't loaded with `gp(n)`