### PR TITLE
decomp: remove popup error for decomp failure and type-cast auto-populator

### DIFF
--- a/src/decomp/decomp-tools.ts
+++ b/src/decomp/decomp-tools.ts
@@ -36,20 +36,26 @@ const decompStatusItem = vscode.window.createStatusBarItem(
 enum DecompStatus {
   Idle,
   Running,
+  Errored,
 }
 
 function updateStatus(status: DecompStatus, metadata?: any) {
   let subText = "";
   switch (status) {
+    case DecompStatus.Errored:
+      decompStatusItem.tooltip = "Toggle Auto-Decomp";
+      decompStatusItem.command = "opengoal.decomp.toggleAutoDecompilation";
+      decompStatusItem.text = "$(testing-error-icon) Decomp Failed";
+      break;
     case DecompStatus.Idle:
-      decompStatusItem.tooltip = "Toggle Auto-Decompilation";
+      decompStatusItem.tooltip = "Toggle Auto-Decomp";
       decompStatusItem.command = "opengoal.decomp.toggleAutoDecompilation";
       if (fsWatcher === undefined) {
         decompStatusItem.text =
-          "$(extensions-sync-ignored) Auto-Decompilation Disabled";
+          "$(extensions-sync-ignored) Auto-Decomp Disabled";
       } else {
         decompStatusItem.text =
-          "$(extensions-sync-enabled) Auto-Decompilation Enabled";
+          "$(extensions-sync-enabled) Auto-Decomp Enabled";
       }
       break;
     case DecompStatus.Running:
@@ -211,15 +217,13 @@ async function decompFiles(decompConfig: string, fileNames: string[]) {
     );
     channel.append(stdout.toString());
     channel.append(stderr.toString());
+    updateStatus(DecompStatus.Idle);
   } catch (error: any) {
-    vscode.window.showErrorMessage(
-      "Decompilation Failed, see OpenGOAL Decompiler logs for details"
-    );
+    updateStatus(DecompStatus.Errored);
     channel.append(
       `DECOMP ERROR:\nSTDOUT:\n${error.stdout}\nSTDERR:\n${error.stderr}`
     );
   }
-  updateStatus(DecompStatus.Idle);
 }
 
 async function getValidObjectNames(gameName: string) {

--- a/src/decomp/type-caster.ts
+++ b/src/decomp/type-caster.ts
@@ -100,17 +100,15 @@ export async function updateTypeCastSuggestions(gameName: GameName) {
       {
         encoding: "utf8",
         cwd: getProjectRoot().fsPath,
-        timeout: 20000,
+        timeout: 500,
       }
     );
     if (existsSync(jsonPath)) {
       const result = readFileSync(jsonPath, { encoding: "utf-8" });
       typeCastSuggestions.set(gameName, JSON.parse(result));
     }
-  } catch (error: any) {
-    vscode.window.showErrorMessage(
-      "Couldn't get a list of all types to use for casting suggestions"
-    );
+  } catch (error: unknown) {
+    /* empty */
   }
 }
 


### PR DESCRIPTION
Both these are annoying and get in the way, especially if you have right-side terminals open.

Decomp failures will have a "red" error icon indicator on the status bar now.