### PR TITLE
decomp: auto generate docstring stub for methods/functions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,12 +13,13 @@ import { activateTypeCastTools } from "./decomp/type-caster";
 import { IRInlayHintsProvider } from "./languages/ir2/ir2-inlay-hinter";
 import { OpenGOALDisasmRenameProvider } from "./languages/opengoal/disasm/opengoal-disasm-renamer";
 import { activateMiscDecompTools } from "./decomp/misc-tools";
-import { IR2RenameProvider } from "./languages/ir2/ir2-renamer";
+import { IRRenameProvider } from "./languages/ir2/ir2-renamer";
 import {
   onChangeSelection,
   onChangeTextDocument,
   registerParinferCommands,
 } from "./goal/parinfer/parinfer";
+import { IRCompletionItemProvider } from "./languages/ir2/ir2-completions";
 
 export async function activate(context: vscode.ExtensionContext) {
   try {
@@ -75,7 +76,12 @@ export async function activate(context: vscode.ExtensionContext) {
     );
     vscode.languages.registerRenameProvider(
       { scheme: "file", language: "opengoal-ir" },
-      new IR2RenameProvider()
+      new IRRenameProvider()
+    );
+    vscode.languages.registerCompletionItemProvider(
+      { scheme: "file", language: "opengoal-ir" },
+      new IRCompletionItemProvider(),
+      "@" // NOTE - can't use `"` without overriding a default setting https://github.com/microsoft/vscode/issues/131238#issuecomment-902519923
     );
 
     // Start the LSP

--- a/src/languages/ir2/ir2-completions.ts
+++ b/src/languages/ir2/ir2-completions.ts
@@ -1,0 +1,58 @@
+import * as vscode from "vscode";
+import { getArgumentsInSignature } from "../opengoal/opengoal-tools";
+
+export class IRCompletionItemProvider implements vscode.CompletionItemProvider {
+  provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken,
+    context: vscode.CompletionContext
+  ): vscode.ProviderResult<
+    vscode.CompletionItem[] | vscode.CompletionList<vscode.CompletionItem>
+  > {
+    // Currently, this is used to automatically generate docstrings for `defmethods` and `defun`
+    // NOTE - assumes single line signatures!
+
+    // Find the signature line
+    const prevLine = document.lineAt(position.line - 1).text;
+    if (!prevLine.includes("defmethod") && !prevLine.includes("defun")) {
+      return [];
+    }
+
+    const args = getArgumentsInSignature(prevLine);
+    if (args.length <= 0) {
+      return [];
+    }
+
+    const range = new vscode.Range(position, position);
+    const rangeToRemove = new vscode.Range(
+      position.line,
+      position.character - 1,
+      position.line,
+      position.character
+    );
+
+    let docstring = `"something\n`;
+    for (const arg of args) {
+      docstring += ` @param ${arg.name} something\n`;
+    }
+    docstring += ` @returns something"`;
+
+    return [
+      {
+        label: "Auto-Generated Docstring",
+        kind: vscode.CompletionItemKind.Text,
+        range: range,
+        insertText: docstring,
+        additionalTextEdits: [vscode.TextEdit.delete(rangeToRemove)],
+      },
+    ];
+  }
+
+  resolveCompletionItem?(
+    item: vscode.CompletionItem,
+    token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.CompletionItem> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/src/languages/ir2/ir2-renamer.ts
+++ b/src/languages/ir2/ir2-renamer.ts
@@ -4,7 +4,7 @@ import { getSymbolAtPosition } from "../common/utils";
 import { getSymbolsArgumentInfo } from "../opengoal/opengoal-tools";
 import { getFuncNameFromPosition, insideGoalCodeInIR } from "./ir2-utils";
 
-export class IR2RenameProvider implements vscode.RenameProvider {
+export class IRRenameProvider implements vscode.RenameProvider {
   public async provideRenameEdits(
     document: vscode.TextDocument,
     position: vscode.Position,


### PR DESCRIPTION
Type `@` the line after a `defmethod` or `defun` in the IR2 file to generate a stub with the correct arg names, etc.  Nothing too fancy yet