### PR TITLE
decomp: adjust decompiling to use new `--version` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "publisher": "opengoal",
   "version": "0.13.0",
   "engines": {
-    "vscode": "^1.74.0"
+    "vscode": "^1.76.0"
   },
   "categories": [
     "Programming Languages"
@@ -30,7 +30,7 @@
     "@types/follow-redirects": "^1.14.1",
     "@types/glob": "^8.0.1",
     "@types/node": "^17.0.45",
-    "@types/vscode": "^1.74.0",
+    "@types/vscode": "^1.76.0",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.53.0",
     "eslint": "^8.35.0",
@@ -45,33 +45,7 @@
     "parinfer": "^3.13.1",
     "vscode-languageclient": "^8.0.1"
   },
-  "activationEvents": [
-    "onLanguage:opengoal",
-    "onLanguage:opengoal-goos",
-    "onLanguage:opengoal-ir",
-    "onCommand:opengoal.switchFile",
-    "onCommand:opengoal.decomp.openManPage",
-    "onCommand:opengoal.decomp.decompileSpecificFile",
-    "onCommand:opengoal.decomp.decompileCurrentFile",
-    "onCommand:opengoal.decomp.toggleAutoDecompilation",
-    "onCommand:opengoal.decomp.updateSourceFile",
-    "onCommand:opengoal.decomp.updateReferenceTest",
-    "onCommand:opengoal.decomp.casts.repeatLast",
-    "onCommand:opengoal.decomp.casts.labelCastSelection",
-    "onCommand:opengoal.decomp.casts.stackCastSelection",
-    "onCommand:opengoal.decomp.casts.typeCastSelection",
-    "onCommand:opengoal.decomp.misc.addToOffsets",
-    "onCommand:opengoal.decomp.misc.preserveBlock",
-    "onCommand:opengoal.decomp.misc.convertHexToDec",
-    "onCommand:opengoal.decomp.misc.convertDecToHex",
-    "onCommand:opengoal.decomp.misc.generateTypeFlags",
-    "onCommand:opengoal.decomp.misc.genTypeFields",
-    "onCommand:opengoal.decomp.misc.genMethodStubs",
-    "onCommand:opengoal.decomp.typeSearcher.open",
-    "onCommand:opengoal.lsp.start",
-    "onCommand:opengoal.lsp.stop",
-    "onCommand:opengoal.lsp.restart"
-  ],
+  "activationEvents": [],
   "contributes": {
     "commands": [
       {

--- a/package.json
+++ b/package.json
@@ -230,37 +230,21 @@
             "default": null,
             "description": "File path to the type searcher executable"
           },
-          "opengoal.decompilerJak1Config": {
+          "opengoal.decompilerJak1ConfigVersion": {
             "type": [
               "string",
               "null"
             ],
-            "default": null,
-            "description": "Config to use for decompiling jak 1 related files"
+            "default": "ntsc_v1",
+            "description": "Config version to use for decompiling jak 1 related files"
           },
-          "opengoal.decompilerJak2Config": {
+          "opengoal.decompilerJak2ConfigVersion": {
             "type": [
               "string",
               "null"
             ],
-            "default": null,
-            "description": "Config to use for decompiling jak 2 related files"
-          },
-          "opengoal.decompilerJak1ConfigDirectory": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null,
-            "description": "Directory containing cast files to use for decompiling jak 1 related files"
-          },
-          "opengoal.decompilerJak2ConfigDirectory": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null,
-            "description": "Directory containing cast files to use for decompiling jak 2 related files"
+            "default": "ntsc_v1",
+            "description": "Config version to use for decompiling jak 2 related files"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -205,18 +205,12 @@
             "description": "File path to the type searcher executable"
           },
           "opengoal.decompilerJak1ConfigVersion": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "default": "ntsc_v1",
             "description": "Config version to use for decompiling jak 1 related files"
           },
           "opengoal.decompilerJak2ConfigVersion": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": "string",
             "default": "ntsc_v1",
             "description": "Config version to use for decompiling jak 2 related files"
           }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -16,10 +16,12 @@ export function getConfig() {
     decompilerPath: configOptions.get<string>("decompilerPath"),
     typeSearcherPath: configOptions.get<string>("typeSearcherPath"),
     jak1DecompConfigVersion: configOptions.get<string>(
-      "decompilerJak1ConfigVersion"
+      "decompilerJak1ConfigVersion",
+      "ntsc_v1"
     ),
     jak2DecompConfigVersion: configOptions.get<string>(
-      "decompilerJak2ConfigVersion"
+      "decompilerJak2ConfigVersion",
+      "ntsc_v1"
     ),
     colorsGoalGlobals: configOptions.get<string>("colors.goal.entity.global"),
     colorsGoalStorageControl: configOptions.get<string>(

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -15,13 +15,11 @@ export function getConfig() {
     vuManPagePath: configOptions.get<string>("vuManPagePath"),
     decompilerPath: configOptions.get<string>("decompilerPath"),
     typeSearcherPath: configOptions.get<string>("typeSearcherPath"),
-    jak1DecompConfig: configOptions.get<string>("decompilerJak1Config"),
-    jak2DecompConfig: configOptions.get<string>("decompilerJak2Config"),
-    decompilerJak1ConfigDirectory: configOptions.get<string>(
-      "decompilerJak1ConfigDirectory"
+    jak1DecompConfigVersion: configOptions.get<string>(
+      "decompilerJak1ConfigVersion"
     ),
-    decompilerJak2ConfigDirectory: configOptions.get<string>(
-      "decompilerJak2ConfigDirectory"
+    jak2DecompConfigVersion: configOptions.get<string>(
+      "decompilerJak2ConfigVersion"
     ),
     colorsGoalGlobals: configOptions.get<string>("colors.goal.entity.global"),
     colorsGoalStorageControl: configOptions.get<string>(
@@ -81,42 +79,6 @@ export async function updateTypeSearcherPath(path: string) {
   await userConfig.update(
     "opengoal.typeSearcherPath",
     path,
-    vscode.ConfigurationTarget.Global
-  );
-}
-
-export async function updateJak1DecompConfig(config: string) {
-  const userConfig = vscode.workspace.getConfiguration();
-  await userConfig.update(
-    "opengoal.decompilerJak1Config",
-    config,
-    vscode.ConfigurationTarget.Global
-  );
-}
-
-export async function updateJak2DecompConfig(config: string) {
-  const userConfig = vscode.workspace.getConfiguration();
-  await userConfig.update(
-    "opengoal.decompilerJak2Config",
-    config,
-    vscode.ConfigurationTarget.Global
-  );
-}
-
-export async function updateJak1DecompConfigDirectory(dir: string) {
-  const userConfig = vscode.workspace.getConfiguration();
-  await userConfig.update(
-    "opengoal.decompilerJak1ConfigDirectory",
-    dir,
-    vscode.ConfigurationTarget.Global
-  );
-}
-
-export async function updateJak2DecompConfigDirectory(dir: string) {
-  const userConfig = vscode.workspace.getConfiguration();
-  await userConfig.update(
-    "opengoal.decompilerJak2ConfigDirectory",
-    dir,
     vscode.ConfigurationTarget.Global
   );
 }

--- a/src/decomp/decomp-tools.ts
+++ b/src/decomp/decomp-tools.ts
@@ -4,12 +4,7 @@ import * as vscode from "vscode";
 import { determineGameFromPath, GameName } from "../utils/file-utils";
 import { open_in_pdf } from "./man-page";
 import * as util from "util";
-import {
-  getConfig,
-  updateDecompilerPath,
-  updateJak1DecompConfig,
-  updateJak2DecompConfig,
-} from "../config/config";
+import { getConfig, updateDecompilerPath } from "../config/config";
 import * as path from "path";
 import * as glob from "glob";
 import { getExtensionContext, getProjectRoot } from "../context";
@@ -86,70 +81,38 @@ function defaultDecompPath() {
   }
 }
 
-async function promptUserToSelectConfig(
-  projectRoot: vscode.Uri
-): Promise<string | undefined> {
-  // Get all `.jsonc` files in ./decompiler/config
-  const configs = await globAsync("decompiler/config/*.jsonc", {
-    cwd: projectRoot.fsPath,
-  });
-  const options = [];
-  for (const config of configs) {
-    options.push(path.basename(config));
+function getDecompilerConfig(gameName: GameName): string | undefined {
+  let decompConfigPath = undefined;
+  if (gameName == GameName.Jak1) {
+    decompConfigPath = vscode.Uri.joinPath(
+      getProjectRoot(),
+      `decompiler/config/jak1/jak1_config.jsonc`
+    ).fsPath;
+  } else if (gameName == GameName.Jak2) {
+    decompConfigPath = vscode.Uri.joinPath(
+      getProjectRoot(),
+      `decompiler/config/jak2/jak2_config.jsonc`
+    ).fsPath;
   }
-  return await vscode.window.showQuickPick(options, {
-    title: "Config?",
-  });
+  if (decompConfigPath === undefined || !existsSync(decompConfigPath)) {
+    return undefined;
+  } else {
+    return decompConfigPath;
+  }
 }
 
-async function getDecompilerConfig(
-  gameName: GameName
-): Promise<string | undefined> {
-  const config = getConfig();
+function getDecompilerConfigVersion(gameName: GameName): string {
+  let version = undefined;
   if (gameName == GameName.Jak1) {
-    const decompConfig = config.jak1DecompConfig;
-    if (
-      decompConfig === undefined ||
-      !existsSync(
-        vscode.Uri.joinPath(
-          getProjectRoot(),
-          `decompiler/config/${decompConfig}`
-        ).fsPath
-      )
-    ) {
-      const config = await promptUserToSelectConfig(getProjectRoot());
-      if (config === undefined) {
-        return;
-      } else {
-        updateJak1DecompConfig(config);
-        return config;
-      }
-    } else {
-      return decompConfig;
-    }
+    version = getConfig().jak1DecompConfigVersion;
   } else if (gameName == GameName.Jak2) {
-    const decompConfig = config.jak2DecompConfig;
-    if (
-      decompConfig === undefined ||
-      !existsSync(
-        vscode.Uri.joinPath(
-          getProjectRoot(),
-          `decompiler/config/${decompConfig}`
-        ).fsPath
-      )
-    ) {
-      const config = await promptUserToSelectConfig(getProjectRoot());
-      if (config === undefined) {
-        return;
-      } else {
-        updateJak2DecompConfig(config);
-        return config;
-      }
-    } else {
-      return decompConfig;
-    }
+    version = getConfig().jak2DecompConfigVersion;
   }
-  return undefined;
+  if (version === undefined) {
+    return "ntsc_v1";
+  } else {
+    return version;
+  }
 }
 
 async function checkDecompilerPath(): Promise<string | undefined> {
@@ -185,7 +148,11 @@ async function checkDecompilerPath(): Promise<string | undefined> {
   return decompilerPath;
 }
 
-async function decompFiles(decompConfig: string, fileNames: string[]) {
+async function decompFiles(
+  decompConfig: string,
+  gameName: GameName,
+  fileNames: string[]
+) {
   if (fileNames.length == 0) {
     return;
   }
@@ -197,24 +164,23 @@ async function decompFiles(decompConfig: string, fileNames: string[]) {
   const allowed_objects = fileNames.map((name) => `"${name}"`).join(",");
   updateStatus(DecompStatus.Running, {
     objectNames: fileNames,
-    decompConfig: decompConfig,
+    decompConfig: path.parse(decompConfig).name,
   });
   try {
-    const { stdout, stderr } = await execFileAsync(
-      decompilerPath,
-      [
-        `./decompiler/config/${decompConfig}`,
-        "./iso_data",
-        "./decompiler_out",
-        "--config-override",
-        `{"decompile_code": true, "levels_extract": false, "allowed_objects": [${allowed_objects}]}`,
-      ],
-      {
-        encoding: "utf8",
-        cwd: getProjectRoot()?.fsPath,
-        timeout: 20000,
-      }
-    );
+    const args = [
+      decompConfig,
+      "./iso_data",
+      "./decompiler_out",
+      "--version",
+      getDecompilerConfigVersion(gameName),
+      "--config-override",
+      `{"decompile_code": true, "levels_extract": false, "allowed_objects": [${allowed_objects}]}`,
+    ];
+    const { stdout, stderr } = await execFileAsync(decompilerPath, args, {
+      encoding: "utf8",
+      cwd: getProjectRoot()?.fsPath,
+      timeout: 20000,
+    });
     channel.append(stdout.toString());
     channel.append(stderr.toString());
     updateStatus(DecompStatus.Idle);
@@ -292,7 +258,7 @@ async function decompSpecificFile() {
   }
 
   // Determine what decomp config to use
-  const decompConfig = await getDecompilerConfig(gameName);
+  const decompConfig = getDecompilerConfig(gameName);
   if (decompConfig === undefined) {
     await vscode.window.showErrorMessage(
       `OpenGOAL - Can't decompile no ${gameName.toString} config selected`
@@ -300,7 +266,7 @@ async function decompSpecificFile() {
     return;
   }
 
-  await decompFiles(decompConfig, [fileName]);
+  await decompFiles(decompConfig, gameName, [fileName]);
 }
 
 async function decompCurrentFile() {
@@ -323,14 +289,14 @@ async function decompCurrentFile() {
   }
 
   // Determine what decomp config to use
-  const gameName = await determineGameFromPath(editor.document.uri);
+  const gameName = determineGameFromPath(editor.document.uri);
   if (gameName === undefined) {
     await vscode.window.showErrorMessage(
       "OpenGOAL - Can't decompile, couldn't determine game from file"
     );
     return;
   }
-  const decompConfig = await getDecompilerConfig(gameName);
+  const decompConfig = getDecompilerConfig(gameName);
   if (decompConfig === undefined) {
     await vscode.window.showErrorMessage(
       `OpenGOAL - Can't decompile no ${gameName.toString} config selected`
@@ -338,7 +304,7 @@ async function decompCurrentFile() {
     return;
   }
 
-  await decompFiles(decompConfig, [fileName]);
+  await decompFiles(decompConfig, gameName, [fileName]);
 }
 
 async function decompAllActiveFiles() {
@@ -352,25 +318,25 @@ async function decompAllActiveFiles() {
   );
 
   if (jak1ObjectNames.length > 0) {
-    const jak1Config = await getDecompilerConfig(GameName.Jak1);
+    const jak1Config = getDecompilerConfig(GameName.Jak1);
     if (jak1Config === undefined) {
       await vscode.window.showErrorMessage(
         "OpenGOAL - Can't decompile no Jak 1 config selected"
       );
       return;
     }
-    await decompFiles(jak1Config, jak1ObjectNames);
+    await decompFiles(jak1Config, GameName.Jak1, jak1ObjectNames);
   }
 
   if (jak2ObjectNames.length > 0) {
-    const jak2Config = await getDecompilerConfig(GameName.Jak2);
+    const jak2Config = getDecompilerConfig(GameName.Jak2);
     if (jak2Config === undefined) {
       await vscode.window.showErrorMessage(
         "OpenGOAL - Can't decompile no Jak 2 config selected"
       );
       return;
     }
-    await decompFiles(jak2Config, jak2ObjectNames);
+    await decompFiles(jak2Config, GameName.Jak2, jak2ObjectNames);
   }
 }
 

--- a/src/decomp/utils.ts
+++ b/src/decomp/utils.ts
@@ -40,18 +40,6 @@ export function getCastFileData(
   return parse(readFileSync(castFilePath).toString(), undefined, true);
 }
 
-async function promptUserToSelectConfigDirectory(
-  projectRoot: vscode.Uri
-): Promise<string | undefined> {
-  // Get all `.jsonc` files in ./decompiler/config
-  const dirs = await getDirectoriesInDir(
-    vscode.Uri.joinPath(projectRoot, "decompiler/config").fsPath
-  );
-  return await vscode.window.showQuickPick(dirs, {
-    title: "Config?",
-  });
-}
-
 export function getDecompilerConfigDirectory(
   activeFile: vscode.Uri
 ): string | undefined {
@@ -68,12 +56,14 @@ export function getDecompilerConfigDirectory(
   if (gameName == GameName.Jak1) {
     decompConfigPath = vscode.Uri.joinPath(
       projectRoot,
-      `decompiler/config/jak1/`
+      `decompiler/config/jak1/`,
+      getConfig().jak1DecompConfigVersion
     ).fsPath;
   } else if (gameName == GameName.Jak2) {
     decompConfigPath = vscode.Uri.joinPath(
       projectRoot,
-      `decompiler/config/jak2/`
+      `decompiler/config/jak2/`,
+      getConfig().jak1DecompConfigVersion
     ).fsPath;
   }
   if (decompConfigPath === undefined || !existsSync(decompConfigPath)) {

--- a/src/decomp/utils.ts
+++ b/src/decomp/utils.ts
@@ -2,11 +2,7 @@ import { parse, stringify } from "comment-json";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import * as vscode from "vscode";
-import {
-  getConfig,
-  updateJak1DecompConfigDirectory,
-  updateJak2DecompConfigDirectory,
-} from "../config/config";
+import { getConfig } from "../config/config";
 import { ArgumentMeta } from "../languages/opengoal/opengoal-tools";
 import {
   determineGameFromPath,
@@ -25,29 +21,23 @@ export function getCastFileData(
     return undefined;
   }
   const config = getConfig();
-  let decompConfigPath = "";
+  let castFilePath = "";
   if (gameName == GameName.Jak1) {
-    const path = config.decompilerJak1ConfigDirectory;
-    if (path === undefined) {
-      return undefined;
-    }
-    decompConfigPath = path;
+    castFilePath = vscode.Uri.joinPath(
+      projectRoot,
+      `decompiler/config/jak1/${config.jak2DecompConfigVersion}/${fileName}`
+    ).fsPath;
   } else if (gameName == GameName.Jak2) {
-    const path = config.decompilerJak2ConfigDirectory;
-    if (path === undefined) {
-      return undefined;
-    }
-    decompConfigPath = path;
+    castFilePath = vscode.Uri.joinPath(
+      projectRoot,
+      `decompiler/config/jak2/${config.jak2DecompConfigVersion}/${fileName}`
+    ).fsPath;
   }
-  const path = vscode.Uri.joinPath(
-    projectRoot,
-    `decompiler/config/${decompConfigPath}/${fileName}`
-  ).fsPath;
-  if (!existsSync(path)) {
+  if (!existsSync(castFilePath)) {
     return undefined;
   }
 
-  return parse(readFileSync(path).toString(), undefined, true);
+  return parse(readFileSync(castFilePath).toString(), undefined, true);
 }
 
 async function promptUserToSelectConfigDirectory(
@@ -62,9 +52,9 @@ async function promptUserToSelectConfigDirectory(
   });
 }
 
-export async function getDecompilerConfigDirectory(
+export function getDecompilerConfigDirectory(
   activeFile: vscode.Uri
-): Promise<string | undefined> {
+): string | undefined {
   const projectRoot = getWorkspaceFolderByName("jak-project");
   if (projectRoot === undefined) {
     vscode.window.showErrorMessage(
@@ -73,64 +63,23 @@ export async function getDecompilerConfigDirectory(
     return undefined;
   }
 
-  const config = getConfig();
   const gameName = determineGameFromPath(activeFile);
+  let decompConfigPath = undefined;
   if (gameName == GameName.Jak1) {
-    if (
-      config.decompilerJak1ConfigDirectory === undefined ||
-      !existsSync(
-        vscode.Uri.joinPath(
-          projectRoot,
-          "decompiler/config/",
-          config.decompilerJak1ConfigDirectory
-        ).fsPath
-      )
-    ) {
-      const selection = await promptUserToSelectConfigDirectory(projectRoot);
-      if (selection === undefined) {
-        vscode.window.showErrorMessage(
-          "OpenGOAL - Can't cast without knowing where to store them!"
-        );
-        return undefined;
-      }
-      await updateJak1DecompConfigDirectory(selection);
-      return vscode.Uri.joinPath(projectRoot, "decompiler/config/", selection)
-        .fsPath;
-    } else {
-      return vscode.Uri.joinPath(
-        projectRoot,
-        "decompiler/config/",
-        config.decompilerJak1ConfigDirectory
-      ).fsPath;
-    }
+    decompConfigPath = vscode.Uri.joinPath(
+      projectRoot,
+      `decompiler/config/jak1/`
+    ).fsPath;
   } else if (gameName == GameName.Jak2) {
-    if (
-      config.decompilerJak2ConfigDirectory === undefined ||
-      !existsSync(
-        vscode.Uri.joinPath(
-          projectRoot,
-          "decompiler/config/",
-          config.decompilerJak2ConfigDirectory
-        ).fsPath
-      )
-    ) {
-      const selection = await promptUserToSelectConfigDirectory(projectRoot);
-      if (selection === undefined) {
-        vscode.window.showErrorMessage(
-          "OpenGOAL - Can't cast without knowing where to store them!"
-        );
-        return undefined;
-      }
-      await updateJak2DecompConfigDirectory(selection);
-      return vscode.Uri.joinPath(projectRoot, "decompiler/config/", selection)
-        .fsPath;
-    } else {
-      return vscode.Uri.joinPath(
-        projectRoot,
-        "decompiler/config/",
-        config.decompilerJak2ConfigDirectory
-      ).fsPath;
-    }
+    decompConfigPath = vscode.Uri.joinPath(
+      projectRoot,
+      `decompiler/config/jak2/`
+    ).fsPath;
+  }
+  if (decompConfigPath === undefined || !existsSync(decompConfigPath)) {
+    return undefined;
+  } else {
+    return decompConfigPath;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,10 +102,10 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
-"@types/vscode@^1.74.0":
-  version "1.74.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.74.0.tgz#4adc21b4e7f527b893de3418c21a91f1e503bdcd"
-  integrity sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==
+"@types/vscode@^1.76.0":
+  version "1.76.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.76.0.tgz#967c0fbe09921818bbf201f1cbcb81b981c6249c"
+  integrity sha512-CQcY3+Fe5hNewHnOEAVYj4dd1do/QHliXaknAEYSXx2KEHUzFibDZSKptCon+HPgK55xx20pR+PBJjf0MomnBA==
 
 "@typescript-eslint/eslint-plugin@^5.54.0":
   version "5.54.0"


### PR DESCRIPTION
Recent changes in `jak-project` change the way you run the decompiler, this cleaned up quite a bit thankfully.