### PR TITLE
decomp: add new feature that lets you bulk rename variables in a selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,10 @@
         "title": "OpenGOAL - Misc - Apply Decompiler Suggestions to Selection"
       },
       {
+        "command": "opengoal.decomp.misc.batchRenameUnnamedVars",
+        "title": "OpenGOAL - Misc - Batch Rename Unnamed Vars"
+      },
+      {
         "command": "opengoal.decomp.typeSearcher.open",
         "title": "OpenGOAL - Misc - Type Searcher"
       },
@@ -413,6 +417,11 @@
           "when": "resourceLangId == opengoal-ir",
           "command": "opengoal.decomp.openManPage",
           "group": "z_commands"
+        }
+      ],
+      "editor/title": [
+        {
+          "when": "resourceScheme == opengoalBatchRename"
         }
       ]
     },

--- a/src/languages/opengoal/opengoal-tools.ts
+++ b/src/languages/opengoal/opengoal-tools.ts
@@ -14,12 +14,12 @@ export interface ArgumentDefinition {
 export function getArgumentsInSignature(
   signature: string,
 ): ArgumentDefinition[] {
-  const isArgument =
+  const isSignature =
     signature.includes("defun") ||
     signature.includes("defmethod") ||
     signature.includes("defbehavior");
 
-  if (!isArgument) {
+  if (!isSignature) {
     return [];
   }
 


### PR DESCRIPTION
![Screenshot 2024-01-23 230253](https://github.com/open-goal/opengoal-vscode/assets/13153231/f00254c2-7d98-4dd9-9e91-2b4e7f5809fc)

Select function body, rename everything, save the file.  There are minimal safe-guards -- know what you are doing.