### PR TITLE
decomp: add a feature that compares two function bodies and if they are the same, copies the name changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,10 @@
         "title": "OpenGOAL - Misc - Batch Rename Unnamed Vars"
       },
       {
+        "command": "opengoal.decomp.misc.compareFuncWithJak2",
+        "title": "OpenGOAL - Misc - Compare Func with Jak 2"
+      },
+      {
         "command": "opengoal.decomp.typeSearcher.open",
         "title": "OpenGOAL - Misc - Type Searcher"
       },


### PR DESCRIPTION
There's some hacks involved here but in most cases this should work and should save a lot of time.  Allows for cleaning up naming across both games at the same time.

https://github.com/open-goal/opengoal-vscode/assets/13153231/f72183f2-062f-49d6-8257-b42bb957b480

Requires a decompiler with the following changes - https://github.com/open-goal/jak-project/pull/3338