### PR TITLE
nrepl: allow customizing nrepl port

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,11 @@
         "id": "opengoal-repl",
         "title": "REPL",
         "properties": {
+          "opengoal.replPort": {
+            "type": "number",
+            "default": 8181,
+            "description": "Port for the nREPL server"
+          },
           "opengoal.replAutoJackIn": {
             "type": "boolean",
             "default": false,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,6 +5,7 @@ export function getConfig() {
 
   return {
     opengoalParinferMode: configOptions.get<string>("parinferMode"),
+    replPort: configOptions.get<number>("replPort"),
     autoReplJackIn: configOptions.get<boolean>("replAutoJackIn"),
     reloadFileOnSave: configOptions.get<boolean>("reloadFileOnSave"),
     launchLspOnStartup: configOptions.get<boolean>("launchLspOnStartup"),

--- a/src/tools/opengoal/nrepl/opengoal-nrepl.ts
+++ b/src/tools/opengoal/nrepl/opengoal-nrepl.ts
@@ -37,8 +37,11 @@ export async function jackIn() {
     socket = new PromiseSocket();
     socket.setEncoding("utf8");
     socket.socket.setTimeout(100);
-    await socket.connect(8181, "127.0.0.1");
-    jackedIn = true;
+    const port = getConfig().replPort;
+    if (port !== undefined) {
+      await socket.connect(port, "127.0.0.1");
+      jackedIn = true;
+    }
   } catch (e) {
     console.error(e);
     socket = undefined;


### PR DESCRIPTION
I'm not going to try to automatically detect and assume the port because the port can be customized via flags or the repl-config. Basically, it needs to be customizable for that reason, and if it is then the problem is solved.  

Additionally because in the long-term, the automatic port assignment based on the game version should be removed from `goalc` as it's a niche user-specific concern -- if someone wants the different games to use different ports they can use the per-game repl configuration.  However what these users probably actually want is a way to disable the nrepl -- something else that can be added to the configuration easily.

Fixes #320

